### PR TITLE
Fixed Android 792 - nativeOpen on 1.2 and Android SDK15

### DIFF
--- a/jni/source/com_couchbase_lite_internal_database_sqlite_SQLiteConnection.cpp
+++ b/jni/source/com_couchbase_lite_internal_database_sqlite_SQLiteConnection.cpp
@@ -93,13 +93,16 @@ JNIEXPORT jlong JNICALL Java_com_couchbase_lite_internal_database_sqlite_SQLiteC
         throw_sqlite3_exception_errcode(env, err, "Could not open database");
         return 0;
     }
-    
+
+    // Once Couchbase Lite change the supported Android API version to 16 or higher,
+    // we should remove following comment out.
+    // https://github.com/couchbase/couchbase-lite-android/issues/792
     // Check that the database is really read/write when that is what we asked for.
-    if ((sqliteFlags & SQLITE_OPEN_READWRITE) && sqlite3_db_readonly(db, NULL)) {
-        throw_sqlite3_exception(env, db, "Could not open the database in read/write mode.");
-        sqlite3_close(db);
-        return 0;
-    }
+//    if ((sqliteFlags & SQLITE_OPEN_READWRITE) && sqlite3_db_readonly(db, NULL)) {
+//        throw_sqlite3_exception(env, db, "Could not open the database in read/write mode.");
+//        sqlite3_close(db);
+//        return 0;
+//    }
     
     // Set the default busy handler to retry automatically before returning SQLITE_BUSY.
     err = sqlite3_busy_timeout(db, BUSY_TIMEOUT_MS);


### PR DESCRIPTION
`sqlite3_db_readonly()` is not supported with sqlite3 3.7.10 or earlier. Android API 15 or earlier uses sqlite 3.4.x or earlier.  This causes error during `System.loadLibrary()`. Till we change the supported Android API version to 16 or higher, we need to disable to check if database is readonly or not.