### PR TITLE
Fixed https://github.com/couchbase/couchbase-lite-java-core/issues/12…

### DIFF
--- a/jni/source/com_couchbase_lite_storage_SQLiteJsonCollator.cpp
+++ b/jni/source/com_couchbase_lite_storage_SQLiteJsonCollator.cpp
@@ -530,18 +530,24 @@ static void registerCollator(sqlite3* db, const char* locale, const char* icuDat
     const char* localeStr = locale;
     if (localeStr == NULL)
         localeStr = DEFAULT_COLLATOR_LOCALE;
-    
+
+#ifdef ANDROID
     Collator* collator = NULL;
     if (icuDataPath != NULL) {
-#ifdef ANDROID
+        // NOTE: Dictionary file is NOT bundled with library. It is separated dictionary file.
         // Set data path:
         setenv("CBL_ICU_PREFIX", icuDataPath, 1);
-#endif
         // Create ICU Collator:
         collator = createCollator(locale);
-    } else
-        LOGE(SQLITE_COLLATOR_TAG, "Failed to create ICU Collator, No ICU Data Path specified");
-    
+    } else {
+        LOGE(SQLITE_COLLATOR_TAG, "Failed to create ICU Collator, No ICU Data Path specified\n");
+    }
+#else // Java
+    // NOTE: Dictionary file is bundled with library
+    // Create ICU Collator:
+    Collator* collator = createCollator(locale);
+#endif
+
     CollatorContext* context = NULL;
     context = new CollatorContext(sqlite_json_colator_Unicode, collator);
     sqlite3_create_collation_v2(db, "JSON", SQLITE_UTF8, context, collateJSON, (void(*)(void*))collator_dtor);


### PR DESCRIPTION
…53 - CBL Java: Unit Test failure: ViewsTest > testSerbianClientNameQuery

- Root cause: Collator instance was not initialized for CBL Java.
- Fix: As Java version of ICU4C library contains the dictionary data in itself, just need to create instance of Collator.